### PR TITLE
Feat/channel telemetry

### DIFF
--- a/arch.drawio
+++ b/arch.drawio
@@ -1,0 +1,183 @@
+<mxfile host="65bd71144e">
+    <diagram id="1aSalthgrgYlIgvV6sug" name="Page-1">
+        <mxGraphModel dx="2086" dy="1017" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="0" fold="1" page="0" pageScale="1" pageWidth="827" pageHeight="1169" background="light-dark(#FFFFFF,#FFFFFF)" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="32" value="Control Plane&#xa;Mgmnt" style="fillColor=none;strokeColor=#5A6C86;dashed=1;verticalAlign=top;fontStyle=1;fontColor=light-dark(#5A6C86,#333333);whiteSpace=wrap;" vertex="1" parent="1">
+                    <mxGeometry x="136" y="164" width="119" height="445" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" value="SFC Launch Package" style="fillColor=none;strokeColor=#5A6C86;dashed=1;verticalAlign=top;fontStyle=0;fontColor=light-dark(#5A6C86,#333333);whiteSpace=wrap;" vertex="1" parent="1">
+                    <mxGeometry x="-218" y="64" width="130" height="315" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="Amazon API &#xa;Gateways" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=light-dark(#232F3E,#333333);fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.api_gateway;" vertex="1" parent="1">
+                    <mxGeometry x="390" y="210" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="AWS Lambda" style="sketch=0;outlineConnect=0;fontColor=light-dark(#232F3E,#333333);gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.lambda_function;" vertex="1" parent="1">
+                    <mxGeometry x="275" y="220" width="58" height="58" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" value="" style="edgeStyle=none;html=1;" edge="1" parent="1" source="6" target="2">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" value="Control Plane UX" style="sketch=0;outlineConnect=0;fontColor=#ffffff;fillColor=#0050ef;strokeColor=#001DBC;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.management_console2;" vertex="1" parent="1">
+                    <mxGeometry x="554" y="214.5" width="78" height="69" as="geometry"/>
+                </mxCell>
+                <mxCell id="7" value="SFC Spec&#xa;MCP Server" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];gradientDirection=north;outlineConnect=0;fontColor=light-dark(#232F3E,#333333);gradientColor=none;fillColor=#1E262E;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.general;" vertex="1" parent="1">
+                    <mxGeometry x="393" y="345" width="68" height="68" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;" edge="1" parent="1" source="2" target="6">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="658" y="259" as="sourcePoint"/>
+                        <mxPoint x="760" y="259" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="13" value="" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=0;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=light-dark(#232F3E,#333333);fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=1;dashPattern=1 1;" vertex="1" parent="1">
+                    <mxGeometry x="-5" y="6" width="665" height="823" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;" edge="1" parent="1" source="14" target="6">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="658" y="259" as="sourcePoint"/>
+                        <mxPoint x="750" y="260" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="510" y="379"/>
+                            <mxPoint x="510" y="249"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="16" value="OT Edge" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=0;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_corporate_data_center;strokeColor=#7D8998;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#5A6C86;dashed=1;dashPattern=1 1;" vertex="1" parent="1">
+                    <mxGeometry x="-241" y="8" width="178" height="540" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;" edge="1" parent="1" source="4" target="2">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="478" y="259" as="sourcePoint"/>
+                        <mxPoint x="405" y="253" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="20" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="18" target="4">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="488" y="269" as="sourcePoint"/>
+                        <mxPoint x="590" y="269" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="23" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="5" target="4">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="343" y="259" as="sourcePoint"/>
+                        <mxPoint x="400" y="259" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="24" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="7" target="5">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="353" y="269" as="sourcePoint"/>
+                        <mxPoint x="410" y="269" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" value="Amazon&#xa;Cognito" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=light-dark(#232F3E,#333333);fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cognito;" vertex="1" parent="1">
+                    <mxGeometry x="564" y="344" width="58" height="58" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="SFC Configs" style="sketch=0;outlineConnect=0;fontColor=#ffffff;fillColor=#0050ef;strokeColor=#001DBC;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.external_sdk;" vertex="1" parent="1">
+                    <mxGeometry x="174.16" y="317" width="49.69" height="57" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="DDB" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=light-dark(#232F3E,#333333);fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;" vertex="1" parent="1">
+                    <mxGeometry x="160" y="210" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="5" value="Amazon Bedrock&#xa;AgentCore&#xa;Runtime" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=light-dark(#232F3E,#333333);fillColor=#01A88D;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.bedrock;" vertex="1" parent="1">
+                    <mxGeometry x="265" y="340" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="SFC Launch&#xa;Packages" style="sketch=0;outlineConnect=0;fontColor=#ffffff;fillColor=#0050ef;strokeColor=#001DBC;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.external_sdk;" vertex="1" parent="1">
+                    <mxGeometry x="174.16" y="407" width="49.69" height="57" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="AWS IoT&lt;div&gt;Core&lt;/div&gt;" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.iot_core;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="210" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="27" value="SFC Config" style="sketch=0;outlineConnect=0;fontColor=#ffffff;fillColor=#0050ef;strokeColor=#001DBC;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.external_sdk;" vertex="1" parent="1">
+                    <mxGeometry x="-175" y="94.5" width="49.69" height="57" as="geometry"/>
+                </mxCell>
+                <mxCell id="28" value="Amazon&lt;div&gt;Cloudwatch&lt;/div&gt;" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="39" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="29" value="AWS IoT&#xa;x509 Cert" style="sketch=0;outlineConnect=0;fontColor=light-dark(#232F3E,#333333);gradientColor=none;fillColor=#7AA116;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.certificate_manager;" vertex="1" parent="1">
+                    <mxGeometry x="-171.91" y="185" width="37.82" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="shell runners" style="sketch=0;outlineConnect=0;fontColor=light-dark(#232F3E,#333333);gradientColor=none;fillColor=#232F3D;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.documents2;" vertex="1" parent="1">
+                    <mxGeometry x="-175" y="287" width="39.51" height="46" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" value="Logs" style="sketch=0;outlineConnect=0;fontColor=#ffffff;fillColor=#0050ef;strokeColor=#001DBC;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.external_sdk;" vertex="1" parent="1">
+                    <mxGeometry x="170.66" y="520" width="49.69" height="57" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=none;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;" edge="1" parent="1" source="30" target="28">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="343" y="259" as="sourcePoint"/>
+                        <mxPoint x="400" y="259" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-24" y="156"/>
+                            <mxPoint x="-24" y="78"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="42" value="OTEL" style="edgeLabel;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontColor=light-dark(#000000,#333333);" vertex="1" connectable="0" parent="34">
+                    <mxGeometry x="-0.6403" y="-1" relative="1" as="geometry">
+                        <mxPoint x="7" y="-14" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="35" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;" edge="1" parent="1" source="30" target="26">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="353" y="269" as="sourcePoint"/>
+                        <mxPoint x="410" y="269" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-58" y="249"/>
+                            <mxPoint x="-58" y="249"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="43" value="MQTT" style="edgeLabel;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontColor=light-dark(#000000,#333333);" vertex="1" connectable="0" parent="35">
+                    <mxGeometry x="0.011" y="1" relative="1" as="geometry">
+                        <mxPoint x="-9" y="-13" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="36" value="SFC Target AWS Services (Payload)" style="fillColor=none;strokeColor=#5A6C86;dashed=1;verticalAlign=top;fontStyle=1;fontColor=light-dark(#5A6C86,#333333);whiteSpace=wrap;" vertex="1" parent="1">
+                    <mxGeometry x="10" y="650" width="524" height="145" as="geometry"/>
+                </mxCell>
+                <mxCell id="37" value="OT &#xa;Equipment" style="sketch=0;outlineConnect=0;fontColor=light-dark(#232F3E,#333333);gradientColor=none;fillColor=#7AA116;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.iot_sitewise_asset;" vertex="1" parent="1">
+                    <mxGeometry x="-212.38" y="402" width="40.47" height="41" as="geometry"/>
+                </mxCell>
+                <mxCell id="41" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="28" target="4">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="-80" y="194" as="sourcePoint"/>
+                        <mxPoint x="50" y="122" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="44" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=openThin;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="26" target="4">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="-78" y="259" as="sourcePoint"/>
+                        <mxPoint x="50" y="259" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="79" y="153"/>
+                            <mxPoint x="304" y="153"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="46" value="S3" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" vertex="1" parent="1">
+                    <mxGeometry x="26" y="684" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="47" value="Kinesis" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.kinesis;" vertex="1" parent="1">
+                    <mxGeometry x="115" y="682" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="48" value="Data Firehose" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.kinesis_data_firehose;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="684" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="49" value="MSK" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.managed_streaming_for_kafka;" vertex="1" parent="1">
+                    <mxGeometry x="325" y="685" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="50" value="AWS IoT" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.iot_core;" vertex="1" parent="1">
+                    <mxGeometry x="423" y="683" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="52" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=openThin;elbow=vertical;startArrow=none;startFill=0;endFill=0;strokeColor=light-dark(#545B64,#333333);rounded=0;fontStyle=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.75;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="30" target="46">
+                    <mxGeometry width="100" relative="1" as="geometry">
+                        <mxPoint x="138" y="98" as="sourcePoint"/>
+                        <mxPoint x="324" y="240" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/lib/constructs/control-plane-api.ts
+++ b/lib/constructs/control-plane-api.ts
@@ -21,6 +21,7 @@ export interface ControlPlaneApiProps {
   configTable: dynamodb.ITable;
   launchPackageTable: dynamodb.ITable;
   controlPlaneStateTable: dynamodb.ITable;
+  telemetryTable: dynamodb.ITable;
 }
 
 /**
@@ -58,12 +59,13 @@ export class ControlPlaneApi extends Construct {
   public readonly fnAgentRemediate: lambda.Function;
   public readonly fnTagExtract: lambda.Function;
   public readonly fnMetrics: lambda.Function;
+  public readonly fnTelemetry: lambda.Function;
   public readonly fnAuthorizer: lambda.Function;
 
   constructor(scope: Construct, id: string, props: ControlPlaneApiProps) {
     super(scope, id);
 
-    const { configsBucket, configTable, launchPackageTable, controlPlaneStateTable } = props;
+    const { configsBucket, configTable, launchPackageTable, controlPlaneStateTable, telemetryTable } = props;
     const region = Stack.of(this).region;
     const account = Stack.of(this).account;
 
@@ -278,6 +280,13 @@ export class ControlPlaneApi extends Construct {
       }),
     );
 
+    // ── fn-telemetry — channel telemetry query ──────────────────────────
+    this.fnTelemetry = mkFn('fn-telemetry', 'telemetry_handler', 256, 15, {
+      TELEMETRY_TABLE_NAME: telemetryTable.tableName,
+    });
+    telemetryTable.grantReadData(this.fnTelemetry);
+    launchPackageTable.grantReadData(this.fnTelemetry);
+
     // ── Tag Extraction — fn-tag-extract ────────────────────────────────
     this.fnTagExtract = mkFn('fn-tag-extract', 'tag_extract_handler', 256, 60);
     this.fnTagExtract.addToRolePolicy(
@@ -369,6 +378,7 @@ export class ControlPlaneApi extends Construct {
       FnAgentRemediateArn: this.lambdaIntegrationUri(this.fnAgentRemediate),
       FnTagExtractArn: this.lambdaIntegrationUri(this.fnTagExtract),
       FnMetricsArn: this.lambdaIntegrationUri(this.fnMetrics),
+      FnTelemetryArn: this.lambdaIntegrationUri(this.fnTelemetry),
       CloudFrontOrigin: 'https://placeholder.cloudfront.net',
     };
 
@@ -421,6 +431,7 @@ export class ControlPlaneApi extends Construct {
       this.fnAgentRemediate,
       this.fnTagExtract,
       this.fnMetrics,
+      this.fnTelemetry,
     ];
     for (const fn of integrationFunctions) {
       fn.addPermission(`ApiGwInvoke-${fn.node.id}`, {
@@ -465,7 +476,8 @@ export class ControlPlaneApi extends Construct {
     const allFunctions = [
       this.fnConfigs, this.fnLaunchPkg, this.fnIotProv, this.fnLogs,
       this.fnGgComp, this.fnIotControl, this.fnAgentCreateConfig,
-      this.fnAgentRemediate, this.fnTagExtract, this.fnMetrics, this.fnAuthorizer,
+      this.fnAgentRemediate, this.fnTagExtract, this.fnMetrics,
+      this.fnTelemetry, this.fnAuthorizer,
     ];
     for (const fn of allFunctions) {
       NagSuppressions.addResourceSuppressions(fn, [

--- a/lib/constructs/launch-package-tables.ts
+++ b/lib/constructs/launch-package-tables.ts
@@ -8,10 +8,12 @@ import { Construct } from 'constructs';
  * Creates:
  *   - LaunchPackageTable  (PK: packageId, SK: createdAt, GSI: configId-index)
  *   - ControlPlaneStateTable (PK: stateKey — singleton "global")
+ *   - TelemetryTable (PK: packageId, SK: timestamp, TTL: 24h)
  */
 export class LaunchPackageTables extends Construct {
   public readonly launchPackageTable: dynamodb.Table;
   public readonly controlPlaneStateTable: dynamodb.Table;
+  public readonly telemetryTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -44,6 +46,17 @@ export class LaunchPackageTables extends Construct {
       pointInTimeRecovery: true,
     });
 
+    // ── TelemetryTable ──────────────────────────────────────────────────
+    this.telemetryTable = new dynamodb.Table(this, 'TelemetryTable', {
+      tableName: 'SFC_Channel_Telemetry',
+      partitionKey: { name: 'packageId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'timestamp', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.DESTROY,
+      pointInTimeRecovery: true,
+      timeToLiveAttribute: 'ttl',
+    });
+
     // ── Outputs ────────────────────────────────────────────────────────
     new CfnOutput(this, 'LaunchPackageTableName', {
       value: this.launchPackageTable.tableName,
@@ -60,6 +73,10 @@ export class LaunchPackageTables extends Construct {
     new CfnOutput(this, 'ControlPlaneStateTableArn', {
       value: this.controlPlaneStateTable.tableArn,
       description: 'DynamoDB singleton state table ARN for SFC Control Plane',
+    });
+    new CfnOutput(this, 'TelemetryTableName', {
+      value: this.telemetryTable.tableName,
+      description: 'DynamoDB table for SFC channel telemetry (24h TTL)',
     });
   }
 }

--- a/lib/constructs/sfc-config-agent-infra.ts
+++ b/lib/constructs/sfc-config-agent-infra.ts
@@ -10,6 +10,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { LaunchPackageTables } from './launch-package-tables';
 import { ControlPlaneApi } from './control-plane-api';
 import { SfcHeartbeatRule } from './heartbeat-rule';
+import { SfcTelemetryRule } from './telemetry-rule';
 
 export interface SfcConfigAgentInfraProps {
   agentRole?: iam.IRole;
@@ -29,6 +30,7 @@ export class SfcConfigAgentInfra extends Construct {
   public readonly cpTables: LaunchPackageTables;
   public readonly cpApi: ControlPlaneApi;
   public readonly heartbeatRule: SfcHeartbeatRule;
+  public readonly telemetryRule: SfcTelemetryRule;
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
 
@@ -225,6 +227,7 @@ def handler(event, context):
       configTable: this.filesTable,
       launchPackageTable: this.cpTables.launchPackageTable,
       controlPlaneStateTable: this.cpTables.controlPlaneStateTable,
+      telemetryTable: this.cpTables.telemetryTable,
     });
 
     this.userPool = this.cpApi.userPool;
@@ -233,6 +236,12 @@ def handler(event, context):
     // ── WP-08b: IoT Heartbeat Rule ────────────────────────────────────
     this.heartbeatRule = new SfcHeartbeatRule(this, 'HeartbeatRule', {
       launchPackageTable: this.cpTables.launchPackageTable,
+      layer: this.cpApi.layer,
+    });
+
+    // ── IoT Telemetry Rule ───────────────────────────────────────────
+    this.telemetryRule = new SfcTelemetryRule(this, 'TelemetryRule', {
+      telemetryTable: this.cpTables.telemetryTable,
       layer: this.cpApi.layer,
     });
 

--- a/lib/constructs/telemetry-rule.ts
+++ b/lib/constructs/telemetry-rule.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import { Duration, Stack } from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as iot from 'aws-cdk-lib/aws-iot';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+import { NagSuppressions } from 'cdk-nag';
+
+/**
+ * SfcTelemetryRule CDK Construct.
+ *
+ * IoT Topic Rule that listens for channel telemetry MQTT messages published by
+ * the edge runner on topic  sfc/{packageId}/telemetry  and invokes a Lambda
+ * function to persist the batch to the TelemetryTable.
+ *
+ * IoT SQL:
+ *   SELECT *, topic(2) AS packageId FROM 'sfc/+/telemetry'
+ */
+export interface SfcTelemetryRuleProps {
+  telemetryTable: dynamodb.ITable;
+  layer: lambda.ILayerVersion;
+}
+
+export class SfcTelemetryRule extends Construct {
+  public readonly fnTelemetryIngestion: lambda.Function;
+  public readonly rule: iot.CfnTopicRule;
+
+  constructor(scope: Construct, id: string, props: SfcTelemetryRuleProps) {
+    super(scope, id);
+
+    const { telemetryTable, layer } = props;
+    const region = Stack.of(this).region;
+    const account = Stack.of(this).account;
+
+    // ── Lambda: telemetry ingestion ───────────────────────────────────
+    this.fnTelemetryIngestion = new lambda.Function(this, 'fn-telemetry-ingestion', {
+      functionName: 'fn-telemetry-ingestion',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'lambda_handlers.telemetry_ingestion_handler.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../src')),
+      layers: [layer],
+      memorySize: 128,
+      timeout: Duration.seconds(15),
+      environment: {
+        TELEMETRY_TABLE_NAME: telemetryTable.tableName,
+      },
+      logRetention: logs.RetentionDays.ONE_MONTH,
+    });
+
+    telemetryTable.grantWriteData(this.fnTelemetryIngestion);
+
+    // ── IAM role for the IoT Rule Action ──────────────────────────────
+    const ruleRole = new iam.Role(this, 'TelemetryRuleRole', {
+      assumedBy: new iam.ServicePrincipal('iot.amazonaws.com'),
+      description: 'Allows IoT telemetry rule to invoke the telemetry ingestion Lambda',
+    });
+    ruleRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['lambda:InvokeFunction'],
+        resources: [this.fnTelemetryIngestion.functionArn],
+      }),
+    );
+
+    // Allow IoT Core to invoke the Lambda (resource-based policy)
+    this.fnTelemetryIngestion.addPermission('IoTRuleInvoke', {
+      principal: new iam.ServicePrincipal('iot.amazonaws.com'),
+      sourceArn: `arn:aws:iot:${region}:${account}:rule/*`,
+    });
+
+    // ── IoT Topic Rule ────────────────────────────────────────────────
+    this.rule = new iot.CfnTopicRule(this, 'SfcTelemetryRule', {
+      topicRulePayload: {
+        sql: "SELECT *, topic(2) AS packageId FROM 'sfc/+/telemetry'",
+        awsIotSqlVersion: '2016-03-23',
+        ruleDisabled: false,
+        actions: [
+          {
+            lambda: {
+              functionArn: this.fnTelemetryIngestion.functionArn,
+            },
+          },
+        ],
+        errorAction: {
+          republish: {
+            roleArn: ruleRole.roleArn,
+            topic: 'sfc/errors/telemetry-rule',
+            qos: 0,
+          },
+        },
+      },
+    });
+
+    // ── CDK Nag Suppressions ──────────────────────────────────────────
+    NagSuppressions.addResourceSuppressions(this.fnTelemetryIngestion, [
+      { id: 'AwsSolutions-IAM4', reason: 'AWSLambdaBasicExecutionRole managed policy is appropriate for the telemetry ingestion Lambda.' },
+      { id: 'AwsSolutions-L1', reason: 'Python 3.12 is the intentional pinned runtime for the telemetry ingestion Lambda.' },
+    ], true);
+  }
+}

--- a/src/edge/runner.py
+++ b/src/edge/runner.py
@@ -971,7 +971,7 @@ def _publish_telemetry_now(iot_cfg: dict) -> None:
     try:
         from awscrt.mqtt import QoS as MqttQoS
         _mqtt_connection.publish(topic=topic, payload=payload, qos=MqttQoS.AT_MOST_ONCE)
-        logger.info("Telemetry published: %d channels", len(channels))
+        #logger.info("Telemetry published: %d channels", len(channels))
     except Exception as exc:
         logger.warning("Telemetry publish failed: %s", exc)
 

--- a/src/edge/runner.py
+++ b/src/edge/runner.py
@@ -52,8 +52,11 @@ _KEY_PATH = _HERE.parent / "iot" / "device.private.key"
 _CA_PATH = _HERE.parent / "iot" / "AmazonRootCA1.pem"
 
 _HEARTBEAT_INTERVAL_S = 5
+_TELEMETRY_INTERVAL_S = 10
 _CREDENTIAL_REFRESH_INTERVAL_S = 21600
 _RECENT_LOG_RING_SIZE = 3
+_TELEMETRY_BUFFER_DIR = _HERE.parent / "telemetry-buffer"
+_TELEMETRY_MAX_PAYLOAD_BYTES = 100_000
 _CREDENTIAL_ENDPOINT_TEMPLATE = (
     "https://{iotEndpoint}/role-aliases/{roleAlias}/credentials"
 )
@@ -72,6 +75,7 @@ _recent_logs_lock = threading.Lock()
 _aws_credentials: dict[str, str] = {}
 _credentials_lock = threading.Lock()
 _diagnostics_enabled = False
+_channel_telemetry_enabled = True
 _otel_processor = None   # set after OTEL init
 _logger_provider = None  # set after OTEL init
 _mqtt_connection = None  # set after MQTT connect
@@ -701,7 +705,7 @@ def _mqtt_reconnect_loop(iot_cfg: dict) -> None:
 
 def _dispatch_control(topic: str, payload: bytes, iot_cfg: dict) -> None:
     """Route incoming MQTT control messages to handlers."""
-    global _diagnostics_enabled, _sfc_proc
+    global _diagnostics_enabled, _channel_telemetry_enabled, _sfc_proc
     try:
         msg = json.loads(payload)
         suffix = topic.split("/")[-1]
@@ -721,6 +725,10 @@ def _dispatch_control(topic: str, payload: bytes, iot_cfg: dict) -> None:
             sfc_version = _detect_sfc_version(sfc_cfg)
             sfc_main_dir = _ensure_sfc_artifacts(sfc_version, sfc_cfg, sfc_bin_dir)
             _restart_sfc(sfc_main_dir, _SFC_CONFIG_PATH, sfc_bin_dir, log_flag)
+
+        elif suffix == "channel-telemetry":
+            _channel_telemetry_enabled = bool(msg.get("enabled", True))
+            logger.info("Channel telemetry set to %s", _channel_telemetry_enabled)
 
         elif suffix == "config-update":
             presigned_url = msg.get("presignedUrl")
@@ -867,6 +875,148 @@ def _heartbeat_loop(iot_cfg: dict) -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# 7. Telemetry publish (File Target → MQTT)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _telemetry_publish_loop(iot_cfg: dict) -> None:
+    """Read JSON files from File Target output dir, batch, publish to MQTT, delete processed."""
+    _TELEMETRY_BUFFER_DIR.mkdir(parents=True, exist_ok=True)
+    while not _shutdown.is_set():
+        _publish_telemetry_now(iot_cfg)
+        _shutdown.wait(timeout=_TELEMETRY_INTERVAL_S)
+
+
+def _downsample_channels(
+    channels: dict[str, list[dict[str, Any]]], max_points: int = 50
+) -> dict[str, list[dict[str, Any]]]:
+    """If a channel has more than max_points samples, average them down to max_points buckets."""
+    result: dict[str, list[dict[str, Any]]] = {}
+    for name, samples in channels.items():
+        if len(samples) <= max_points:
+            result[name] = samples
+            continue
+        bucket_size = len(samples) / max_points
+        downsampled: list[dict[str, Any]] = []
+        for i in range(max_points):
+            start = int(i * bucket_size)
+            end = int((i + 1) * bucket_size)
+            bucket = samples[start:end]
+            if not bucket:
+                continue
+            avg_value = sum(s["value"] for s in bucket if s.get("value") is not None) / len(bucket)
+            mid_ts = bucket[len(bucket) // 2].get("timestamp", "")
+            downsampled.append({"value": round(avg_value, 6), "timestamp": mid_ts})
+        result[name] = downsampled
+    return result
+
+
+def _purge_telemetry_buffer() -> None:
+    """Remove all buffered JSON files to prevent unbounded disk growth."""
+    if not _TELEMETRY_BUFFER_DIR.exists():
+        return
+    for fp in _TELEMETRY_BUFFER_DIR.rglob("*.json"):
+        fp.unlink(missing_ok=True)
+
+
+def _publish_telemetry_now(iot_cfg: dict) -> None:
+    """Read SFC File Target JSON output, collect all channel samples, publish to MQTT."""
+    if not _channel_telemetry_enabled:
+        _purge_telemetry_buffer()
+        return
+    if not _mqtt_connection or not _TELEMETRY_BUFFER_DIR.exists():
+        return
+
+    json_files = sorted(_TELEMETRY_BUFFER_DIR.rglob("*.json"), key=lambda p: p.stat().st_mtime)
+    if not json_files:
+        return
+
+    channels: dict[str, list[dict[str, Any]]] = {}
+    processed_files: list[Path] = []
+
+    for fp in json_files:
+        try:
+            with open(fp) as fh:
+                data = json.load(fh)
+            _extract_channels(data, channels)
+            processed_files.append(fp)
+        except json.JSONDecodeError:
+            pass
+        except Exception:
+            processed_files.append(fp)
+
+    if not channels:
+        for fp in processed_files:
+            fp.unlink(missing_ok=True)
+        return
+
+    channels = _downsample_channels(channels, max_points=50)
+
+    payload = json.dumps({
+        "packageId": iot_cfg["packageId"],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "channels": channels,
+    })
+
+    if len(payload.encode()) > _TELEMETRY_MAX_PAYLOAD_BYTES:
+        keys = list(channels.keys())
+        while len(payload.encode()) > _TELEMETRY_MAX_PAYLOAD_BYTES and keys:
+            del channels[keys.pop()]
+            payload = json.dumps({
+                "packageId": iot_cfg["packageId"],
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "channels": channels,
+            })
+
+    topic = f"sfc/{iot_cfg['packageId']}/telemetry"
+    try:
+        from awscrt.mqtt import QoS as MqttQoS
+        _mqtt_connection.publish(topic=topic, payload=payload, qos=MqttQoS.AT_MOST_ONCE)
+        logger.info("Telemetry published: %d channels", len(channels))
+    except Exception as exc:
+        logger.warning("Telemetry publish failed: %s", exc)
+
+    for fp in processed_files:
+        fp.unlink(missing_ok=True)
+
+
+def _extract_channels(data: Any, channels: dict[str, list[dict[str, Any]]]) -> None:
+    """
+    Extract channel values from SFC File Target JSON output.
+
+    SFC File Target writes arrays of records:
+    [{"sources": {"<Source>": {"values": {"<Ch>": {"value": v, "timestamp": t}}}}}]
+
+    Collects ALL samples per channel as [{value, timestamp}, ...].
+    """
+    if isinstance(data, list):
+        for item in data:
+            _extract_channels(item, channels)
+        return
+
+    if not isinstance(data, dict):
+        return
+
+    sources = data.get("sources") or data.get("Sources") or {}
+    if isinstance(sources, dict):
+        for source_name, source_data in sources.items():
+            if not isinstance(source_data, dict):
+                continue
+            values = source_data.get("values") or source_data.get("Values") or {}
+            if isinstance(values, dict):
+                for channel_name, channel_data in values.items():
+                    key = f"{source_name}/{channel_name}"
+                    if key not in channels:
+                        channels[key] = []
+                    if isinstance(channel_data, dict):
+                        channels[key].append({
+                            "value": channel_data.get("value", channel_data.get("Value")),
+                            "timestamp": channel_data.get("timestamp", channel_data.get("Timestamp", "")),
+                        })
+                    else:
+                        channels[key].append({"value": channel_data, "timestamp": ""})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 8. Graceful shutdown
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -992,6 +1142,15 @@ def main() -> None:
         name="cred-refresh",
     )
     cred_thread.start()
+
+    # Step 8: Start telemetry publish thread (File Target → MQTT)
+    telemetry_thread = threading.Thread(
+        target=_telemetry_publish_loop,
+        args=(iot_cfg,),
+        daemon=True,
+        name="telemetry",
+    )
+    telemetry_thread.start()
 
     # Wait for shutdown signal — SFC subprocess exit does NOT stop the runner
     logger.info("SFC runner active — waiting for shutdown signal")

--- a/src/lambda_handlers/iot_control_handler.py
+++ b/src/lambda_handlers/iot_control_handler.py
@@ -45,6 +45,8 @@ def handler(event: dict, context) -> dict:
 
         if path.endswith("/diagnostics") and method == "PUT":
             return _set_toggle(pkg, "diagnostics", _parse_body(event))
+        if path.endswith("/channel-telemetry") and method == "PUT":
+            return _set_toggle(pkg, "channel-telemetry", _parse_body(event))
         if path.endswith("/config-update") and method == "POST":
             return _push_config_update(pkg, _parse_body(event))
         if path.endswith("/restart") and method == "POST":
@@ -65,6 +67,7 @@ def _get_control_state(pkg: dict) -> dict:
     return _ok({
         "packageId": pkg["packageId"],
         "diagnosticsEnabled": pkg.get("diagnosticsEnabled", False),
+        "channelTelemetryEnabled": pkg.get("channelTelemetryEnabled", True),
         "lastConfigUpdateAt": pkg.get("lastConfigUpdateAt"),
         "lastConfigUpdateVersion": pkg.get("lastConfigUpdateVersion"),
         "lastRestartAt": pkg.get("lastRestartAt"),
@@ -80,7 +83,12 @@ def _set_toggle(pkg: dict, toggle_type: str, body: dict) -> dict:
         return _error(400, "BAD_REQUEST", "'enabled' must be a boolean")
     topic = f"sfc/{pkg['packageId']}/control/{toggle_type}"
     _iot_data.publish(topic=topic, qos=1, payload=json.dumps({"enabled": enabled}))
-    attr_name = "telemetryEnabled" if toggle_type == "telemetry" else "diagnosticsEnabled"
+    _toggle_attr_map = {
+        "telemetry": "telemetryEnabled",
+        "diagnostics": "diagnosticsEnabled",
+        "channel-telemetry": "channelTelemetryEnabled",
+    }
+    attr_name = _toggle_attr_map.get(toggle_type, f"{toggle_type}Enabled")
     ddb_util.update_package(_pkg_table, pkg["packageId"], pkg["createdAt"], {attr_name: enabled})
     return _ok({"message": f"{toggle_type} set to {enabled}"})
 

--- a/src/lambda_handlers/launch_pkg_handler.py
+++ b/src/lambda_handlers/launch_pkg_handler.py
@@ -323,6 +323,27 @@ def _inject_iot_credentials(sfc_config: dict, package_id: str, prov: dict, confi
         for src in sources.values():
             if isinstance(src, dict):
                 src["Metrics"] = {"Enabled": False}
+
+    # ── Inject telemetry File Target (buffers all channel data locally) ──
+    cfg.setdefault("TargetTypes", {}).setdefault("FILE-TARGET", {
+        "JarFiles": ["${MODULES_DIR}/file-target/lib"],
+        "FactoryClassName": "com.amazonaws.sfc.filetarget.FileTargetWriter",
+    })
+    cfg.setdefault("Targets", {})["_SfcTelemetryBuffer"] = {
+        "Active": True,
+        "TargetType": "FILE-TARGET",
+        "Directory": "../telemetry-buffer",
+        "Extension": ".json",
+        "Json": True,
+        "BufferSize": 100,
+        "Compression": "None",
+    }
+    for schedule in cfg.get("Schedules", []):
+        targets_list = schedule.get("Targets", [])
+        if "_SfcTelemetryBuffer" not in targets_list:
+            targets_list.append("_SfcTelemetryBuffer")
+            schedule["Targets"] = targets_list
+
     return cfg
 
 

--- a/src/lambda_handlers/telemetry_handler.py
+++ b/src/lambda_handlers/telemetry_handler.py
@@ -27,7 +27,7 @@ _dynamodb = boto3.resource("dynamodb")
 _telemetry_table = _dynamodb.Table(TELEMETRY_TABLE_NAME)
 _pkg_table = _dynamodb.Table(LAUNCH_PKG_TABLE)
 
-_MAX_SPARKLINE_POINTS = 30
+_MAX_SPARKLINE_POINTS = 1000
 _DEFAULT_LOOKBACK_MINUTES = 5
 _MAX_LOOKBACK_MINUTES = 60
 

--- a/src/lambda_handlers/telemetry_handler.py
+++ b/src/lambda_handlers/telemetry_handler.py
@@ -28,8 +28,9 @@ _telemetry_table = _dynamodb.Table(TELEMETRY_TABLE_NAME)
 _pkg_table = _dynamodb.Table(LAUNCH_PKG_TABLE)
 
 _MAX_SPARKLINE_POINTS = 1000
-_DEFAULT_LOOKBACK_MINUTES = 5
-_MAX_LOOKBACK_MINUTES = 60
+_MAX_TOTAL_POINTS = 10000
+_DEFAULT_LOOKBACK_SECONDS = 30
+_MAX_LOOKBACK_SECONDS = 300
 
 
 def handler(event: dict, _context) -> dict:
@@ -46,13 +47,13 @@ def handler(event: dict, _context) -> dict:
     if not auth_util.can_read(pkg.get("owner"), caller_sub, caller_groups):
         return _error(403, "FORBIDDEN", "You do not have permission to read this package")
 
-    qs = event.get("queryStringParameters") or {}
+    body = json.loads(event.get("body") or "{}")
     try:
-        lookback = min(int(qs.get("lookbackMinutes", _DEFAULT_LOOKBACK_MINUTES)), _MAX_LOOKBACK_MINUTES)
+        lookback_s = min(int(body.get("lookbackSeconds", _DEFAULT_LOOKBACK_SECONDS)), _MAX_LOOKBACK_SECONDS)
     except (ValueError, TypeError):
-        lookback = _DEFAULT_LOOKBACK_MINUTES
+        lookback_s = _DEFAULT_LOOKBACK_SECONDS
 
-    start_iso = (datetime.now(timezone.utc) - timedelta(minutes=lookback)).isoformat()
+    start_iso = (datetime.now(timezone.utc) - timedelta(seconds=lookback_s)).isoformat()
 
     items = _query_telemetry(package_id, start_iso)
 
@@ -77,9 +78,15 @@ def handler(event: dict, _context) -> dict:
                         pass
 
     result_channels = []
+    total_points = 0
     for name, points in sorted(channel_data.items()):
         points.sort(key=lambda p: p[0])
-        recent = points[-_MAX_SPARKLINE_POINTS:]
+        remaining_budget = _MAX_TOTAL_POINTS - total_points
+        if remaining_budget <= 0:
+            break
+        per_channel_cap = min(_MAX_SPARKLINE_POINTS, remaining_budget)
+        recent = points[-per_channel_cap:]
+        total_points += len(recent)
         result_channels.append({
             "name": name,
             "currentValue": recent[-1][1] if recent else None,

--- a/src/lambda_handlers/telemetry_handler.py
+++ b/src/lambda_handlers/telemetry_handler.py
@@ -1,0 +1,121 @@
+"""fn-telemetry: Query channel telemetry data for a Launch Package.
+
+GET /packages/{packageId}/telemetry?lookbackMinutes=5
+
+Returns per-channel current values and sparkline arrays for the UI.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from sfc_cp_utils import ddb as ddb_util, auth as auth_util
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+TELEMETRY_TABLE_NAME = os.environ["TELEMETRY_TABLE_NAME"]
+LAUNCH_PKG_TABLE = os.environ["LAUNCH_PKG_TABLE_NAME"]
+
+_dynamodb = boto3.resource("dynamodb")
+_telemetry_table = _dynamodb.Table(TELEMETRY_TABLE_NAME)
+_pkg_table = _dynamodb.Table(LAUNCH_PKG_TABLE)
+
+_MAX_SPARKLINE_POINTS = 30
+_DEFAULT_LOOKBACK_MINUTES = 5
+_MAX_LOOKBACK_MINUTES = 60
+
+
+def handler(event: dict, _context) -> dict:
+    path_params = event.get("pathParameters") or {}
+    package_id = path_params.get("packageId")
+    if not package_id:
+        return _error(400, "BAD_REQUEST", "packageId is required")
+
+    caller_sub, caller_groups = auth_util.caller(event)
+
+    pkg = ddb_util.get_package(_pkg_table, package_id)
+    if not pkg:
+        return _error(404, "NOT_FOUND", f"Package {package_id} not found")
+    if not auth_util.can_read(pkg.get("owner"), caller_sub, caller_groups):
+        return _error(403, "FORBIDDEN", "You do not have permission to read this package")
+
+    qs = event.get("queryStringParameters") or {}
+    try:
+        lookback = min(int(qs.get("lookbackMinutes", _DEFAULT_LOOKBACK_MINUTES)), _MAX_LOOKBACK_MINUTES)
+    except (ValueError, TypeError):
+        lookback = _DEFAULT_LOOKBACK_MINUTES
+
+    start_iso = (datetime.now(timezone.utc) - timedelta(minutes=lookback)).isoformat()
+
+    items = _query_telemetry(package_id, start_iso)
+
+    channel_data: dict[str, list[tuple[str, float]]] = defaultdict(list)
+    for item in items:
+        batch_ts = item.get("timestamp", "")
+        channels = item.get("channels", {})
+        if isinstance(channels, dict):
+            for ch_name, ch_value in channels.items():
+                if isinstance(ch_value, list):
+                    for sample in ch_value:
+                        if isinstance(sample, dict):
+                            try:
+                                ts = sample.get("timestamp") or batch_ts
+                                channel_data[ch_name].append((ts, float(sample["value"])))
+                            except (ValueError, TypeError, KeyError):
+                                pass
+                else:
+                    try:
+                        channel_data[ch_name].append((batch_ts, float(ch_value)))
+                    except (ValueError, TypeError):
+                        pass
+
+    result_channels = []
+    for name, points in sorted(channel_data.items()):
+        points.sort(key=lambda p: p[0])
+        recent = points[-_MAX_SPARKLINE_POINTS:]
+        result_channels.append({
+            "name": name,
+            "currentValue": recent[-1][1] if recent else None,
+            "sparkline": [p[1] for p in recent],
+            "timestamps": [p[0] for p in recent],
+        })
+
+    last_updated = items[-1]["timestamp"] if items else None
+
+    return _ok({
+        "packageId": package_id,
+        "channels": result_channels,
+        "lastUpdated": last_updated,
+    })
+
+
+def _query_telemetry(package_id: str, start_iso: str) -> list[dict]:
+    """Query telemetry items from start_iso onwards."""
+    items = []
+    kwargs = {
+        "KeyConditionExpression": Key("packageId").eq(package_id) & Key("timestamp").gte(start_iso),
+        "ScanIndexForward": True,
+    }
+    while True:
+        resp = _telemetry_table.query(**kwargs)
+        items.extend(resp.get("Items", []))
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+    return items
+
+
+def _ok(body):
+    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps(body, default=str)}
+
+
+def _error(s, e, m):
+    return {"statusCode": s, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"error": e, "message": m})}

--- a/src/lambda_handlers/telemetry_ingestion_handler.py
+++ b/src/lambda_handlers/telemetry_ingestion_handler.py
@@ -1,0 +1,85 @@
+"""fn-telemetry-ingestion: IoT Rule Lambda action for channel telemetry.
+
+Receives batched SFC channel telemetry from IoT Core and writes each batch
+as a single item to the TelemetryTable (PK=packageId, SK=timestamp).
+
+IoT SQL: SELECT *, topic(2) AS packageId FROM 'sfc/+/telemetry'
+
+Payload shape (published by runner.py telemetry thread):
+{
+    "packageId": "uuid",
+    "timestamp": "2026-05-28T12:00:05.000Z",
+    "channels": {
+        "SimSource/counter": [{"value": 7.2, "timestamp": "..."}, ...],
+        "SimSource/sinus": [{"value": 3.14, "timestamp": "..."}, ...]
+    }
+}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal
+
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+TELEMETRY_TABLE_NAME = os.environ["TELEMETRY_TABLE_NAME"]
+
+_dynamodb = boto3.resource("dynamodb")
+_telemetry_table = _dynamodb.Table(TELEMETRY_TABLE_NAME)
+
+_TTL_SECONDS = 86400  # 24 hours
+
+
+def _convert_floats(obj):
+    """Recursively convert float values to Decimal for DynamoDB."""
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: _convert_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_convert_floats(i) for i in obj]
+    return obj
+
+
+def handler(event: dict, _context) -> None:
+    """IoT Rule Lambda action entry point."""
+    logger.info("Telemetry event: %s", json.dumps(event, default=str)[:2000])
+
+    package_id: str | None = event.get("packageId")
+    if not package_id:
+        logger.error("packageId missing from telemetry payload — dropping")
+        return
+
+    timestamp: str | None = event.get("timestamp")
+    if not timestamp:
+        logger.error("timestamp missing from telemetry payload — dropping")
+        return
+
+    channels = event.get("channels")
+    if not channels or not isinstance(channels, dict):
+        logger.warning("No channels in telemetry payload for %s — dropping", package_id)
+        return
+
+    item = {
+        "packageId": package_id,
+        "timestamp": timestamp,
+        "channels": _convert_floats(channels),
+        "ttl": int(time.time()) + _TTL_SECONDS,
+    }
+
+    try:
+        _telemetry_table.put_item(Item=item)
+        logger.info(
+            "Telemetry persisted: packageId=%s timestamp=%s channels=%d",
+            package_id, timestamp, len(channels),
+        )
+    except Exception:
+        logger.exception("Failed to write telemetry for packageId=%s", package_id)
+        raise

--- a/src/layer/python/sfc_cp_utils/iot.py
+++ b/src/layer/python/sfc_cp_utils/iot.py
@@ -448,6 +448,11 @@ def _build_iot_policy(package_id: str, region: str, account_id: str) -> dict:
                 "Resource": f"arn:aws:iot:{region}:{account_id}:topic/sfc/{package_id}/heartbeat",
             },
             {
+                "Effect": "Allow",
+                "Action": "iot:Publish",
+                "Resource": f"arn:aws:iot:{region}:{account_id}:topic/sfc/{package_id}/telemetry",
+            },
+            {
                 # Required for the IoT credential provider endpoint to accept
                 # the device certificate and vend temporary AWS credentials.
                 "Effect": "Allow",

--- a/src/openapi/control-plane-api.yaml
+++ b/src/openapi/control-plane-api.yaml
@@ -796,6 +796,38 @@ paths:
         uri: "${FnIotControlArn}"
         payloadFormatVersion: "2.0"
 
+  /packages/{packageId}/control/channel-telemetry:
+    put:
+      operationId: setChannelTelemetry
+      summary: Toggle channel value telemetry on/off for a package
+      tags: [control]
+      parameters:
+        - $ref: "#/components/parameters/packageId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToggleRequest"
+      responses:
+        "200":
+          description: Channel telemetry state updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        httpMethod: POST
+        uri: "${FnIotControlArn}"
+        payloadFormatVersion: "2.0"
+
   /packages/{packageId}/control/config-update:
     post:
       operationId: pushConfigUpdate
@@ -1010,6 +1042,43 @@ paths:
         type: aws_proxy
         httpMethod: POST
         uri: "${FnMetricsArn}"
+        payloadFormatVersion: "2.0"
+
+  # ────────────────────────────────────────────────────────────────
+  # Channel Telemetry
+  # ────────────────────────────────────────────────────────────────
+
+  /packages/{packageId}/telemetry:
+    get:
+      operationId: getChannelTelemetry
+      summary: Get live channel telemetry data with sparkline history
+      tags: [packages]
+      parameters:
+        - $ref: "#/components/parameters/packageId"
+        - name: lookbackMinutes
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 5
+            maximum: 60
+      responses:
+        "200":
+          description: Channel telemetry with sparkline data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TelemetryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        httpMethod: POST
+        uri: "${FnTelemetryArn}"
         payloadFormatVersion: "2.0"
 
   # ────────────────────────────────────────────────────────────────
@@ -1663,6 +1732,43 @@ components:
           type: integer
           description: Chart.js point radius in pixels
       required: [label, data, borderColor]
+
+    # ── Channel Telemetry ────────────────────────────────────────
+
+    TelemetryResponse:
+      type: object
+      properties:
+        packageId:
+          type: string
+        channels:
+          type: array
+          items:
+            $ref: "#/components/schemas/TelemetryChannel"
+        lastUpdated:
+          type: string
+          format: date-time
+          nullable: true
+
+    TelemetryChannel:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Channel identifier (source/channel)"
+        currentValue:
+          type: number
+          nullable: true
+        sparkline:
+          type: array
+          items:
+            type: number
+          description: Recent values (max 30 points)
+        timestamps:
+          type: array
+          items:
+            type: string
+            format: date-time
+      required: [name, sparkline, timestamps]
 
     # ── Remediation ───────────────────────────────────────────────
 

--- a/src/openapi/control-plane-api.yaml
+++ b/src/openapi/control-plane-api.yaml
@@ -1049,19 +1049,23 @@ paths:
   # ────────────────────────────────────────────────────────────────
 
   /packages/{packageId}/telemetry:
-    get:
+    post:
       operationId: getChannelTelemetry
-      summary: Get live channel telemetry data with sparkline history
+      summary: Query live channel telemetry data with sparkline history
       tags: [packages]
       parameters:
         - $ref: "#/components/parameters/packageId"
-        - name: lookbackMinutes
-          in: query
-          required: false
-          schema:
-            type: integer
-            default: 5
-            maximum: 60
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lookbackSeconds:
+                  type: integer
+                  default: 30
+                  maximum: 300
       responses:
         "200":
           description: Channel telemetry with sparkline data

--- a/src/ui/src/api/client.ts
+++ b/src/ui/src/api/client.ts
@@ -97,6 +97,7 @@ export interface HeartbeatStatus {
 export interface ControlState {
   packageId: string;
   diagnosticsEnabled: boolean;
+  channelTelemetryEnabled: boolean;
   lastConfigUpdateAt?: string;
   lastConfigUpdateVersion?: string;
   lastRestartAt?: string;
@@ -290,6 +291,11 @@ export const setDiagnostics = (packageId: string, enabled: boolean) =>
     .put(`/packages/${packageId}/control/diagnostics`, { enabled })
     .then((r) => r.data);
 
+export const setChannelTelemetry = (packageId: string, enabled: boolean) =>
+  api
+    .put(`/packages/${packageId}/control/channel-telemetry`, { enabled })
+    .then((r) => r.data);
+
 export const pushConfigUpdate = (
   packageId: string,
   configId: string,
@@ -432,6 +438,31 @@ export const getPackageMetrics = (
     .post<ChartJsDataset[]>(`/packages/${packageId}/metrics`, {
       category,
       lookbackMinutes,
+    })
+    .then((r) => r.data);
+
+// ─── Channel Telemetry ──────────────────────────────────────────────────────
+
+export interface TelemetryChannel {
+  name: string;
+  currentValue: number | null;
+  sparkline: number[];
+  timestamps: string[];
+}
+
+export interface TelemetryResponse {
+  packageId: string;
+  channels: TelemetryChannel[];
+  lastUpdated: string | null;
+}
+
+export const getChannelTelemetry = (
+  packageId: string,
+  lookbackMinutes = 5
+) =>
+  api
+    .get<TelemetryResponse>(`/packages/${packageId}/telemetry`, {
+      params: { lookbackMinutes },
     })
     .then((r) => r.data);
 

--- a/src/ui/src/api/client.ts
+++ b/src/ui/src/api/client.ts
@@ -458,11 +458,11 @@ export interface TelemetryResponse {
 
 export const getChannelTelemetry = (
   packageId: string,
-  lookbackMinutes = 5
+  lookbackSeconds = 30
 ) =>
   api
-    .get<TelemetryResponse>(`/packages/${packageId}/telemetry`, {
-      params: { lookbackMinutes },
+    .post<TelemetryResponse>(`/packages/${packageId}/telemetry`, {
+      lookbackSeconds,
     })
     .then((r) => r.data);
 

--- a/src/ui/src/components/PackageControlPanel.tsx
+++ b/src/ui/src/components/PackageControlPanel.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getControlState,
   setDiagnostics,
+  setChannelTelemetry,
   pushConfigUpdate,
   restartSfc,
   listConfigs,
@@ -115,6 +116,10 @@ export default function PackageControlPanel({ pkg }: Props) {
     mutationFn: (v: boolean) => setDiagnostics(pkg.packageId, v),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["control", pkg.packageId] }),
   });
+  const chTelMut = useMutation({
+    mutationFn: (v: boolean) => setChannelTelemetry(pkg.packageId, v),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["control", pkg.packageId] }),
+  });
   const cfgPushMut = useMutation({
     mutationFn: () => pushConfigUpdate(pkg.packageId, pushConfigId, pushVersion),
     onSuccess: () => {
@@ -130,6 +135,7 @@ export default function PackageControlPanel({ pkg }: Props) {
   });
 
   const diagnostics = ctrl?.diagnosticsEnabled === true;
+  const channelTelemetry = ctrl?.channelTelemetryEnabled !== false;
 
   return (
     <div className="space-y-4">
@@ -146,6 +152,14 @@ export default function PackageControlPanel({ pkg }: Props) {
       {/* Runtime Controls — Diagnostics toggle + Restart */}
       <div className="card space-y-1">
         <p className="text-xs font-medium text-slate-500 mb-2">Runtime Controls</p>
+
+        <Toggle
+          label="Channel Telemetry"
+          value={channelTelemetry}
+          onApply={(v) => chTelMut.mutate(v)}
+          disabled={!isReady}
+          pending={chTelMut.isPending}
+        />
 
         <Toggle
           label="Diagnostics (TRACE log)"

--- a/src/ui/src/components/TelemetryDashboard.tsx
+++ b/src/ui/src/components/TelemetryDashboard.tsx
@@ -36,10 +36,10 @@ ChartJS.register(
 );
 
 const LOOKBACK_OPTIONS = [
-  { label: "1 min", value: 1 },
-  { label: "5 min", value: 5 },
-  { label: "15 min", value: 15 },
-  { label: "30 min", value: 30 },
+  { label: "15 sec", value: 15 },
+  { label: "30 sec", value: 30 },
+  { label: "1 min", value: 60 },
+  { label: "5 min", value: 300 },
 ];
 
 interface Props {
@@ -224,7 +224,7 @@ function ChannelDetailModal({
 const PAGE_SIZE = 20;
 
 export default function TelemetryDashboard({ packageId }: Props) {
-  const [lookback, setLookback] = useState(5);
+  const [lookback, setLookback] = useState(30);
   const [selectedChannel, setSelectedChannel] = useState<TelemetryChannel | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(0);

--- a/src/ui/src/components/TelemetryDashboard.tsx
+++ b/src/ui/src/components/TelemetryDashboard.tsx
@@ -3,6 +3,8 @@
  *
  * Fetches channel telemetry every 10 seconds and renders a table with:
  *   Channel Name | Current Value | Sparkline (mini Chart.js line) | Last Updated
+ *
+ * Clicking a row opens a detail modal with a full-size chart, data table, and CSV export.
  */
 import {
   Chart as ChartJS,
@@ -11,16 +13,27 @@ import {
   PointElement,
   LineElement,
   Filler,
+  TimeScale,
+  Tooltip,
 } from "chart.js";
+import "chartjs-adapter-date-fns";
 import { Line } from "react-chartjs-2";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   getChannelTelemetry,
   type TelemetryChannel,
 } from "../api/client";
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler);
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  TimeScale,
+  Tooltip
+);
 
 const LOOKBACK_OPTIONS = [
   { label: "1 min", value: 1 },
@@ -67,8 +80,156 @@ function Sparkline({ data }: { data: number[] }) {
   );
 }
 
+function ChannelDetailModal({
+  channel,
+  onClose,
+}: {
+  channel: TelemetryChannel;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const chartData = {
+    labels: channel.timestamps.map((t) => new Date(t)),
+    datasets: [
+      {
+        label: channel.name,
+        data: channel.sparkline,
+        borderColor: "#38bdf8",
+        backgroundColor: "rgba(56,189,248,0.1)",
+        borderWidth: 2,
+        tension: 0.3,
+        fill: true,
+        pointRadius: 2,
+        pointBackgroundColor: "#38bdf8",
+      },
+    ],
+  };
+
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true },
+    },
+    scales: {
+      x: {
+        type: "time" as const,
+        time: { tooltipFormat: "HH:mm:ss" },
+        ticks: { color: "#94a3b8", maxTicksLimit: 10 },
+        grid: { color: "#334155" },
+      },
+      y: {
+        ticks: { color: "#94a3b8" },
+        grid: { color: "#334155" },
+      },
+    },
+    animation: false as const,
+  };
+
+  const handleCopyCsv = () => {
+    const header = "timestamp,value";
+    const rows = channel.timestamps.map(
+      (ts, i) => `${ts},${channel.sparkline[i]}`
+    );
+    const csv = [header, ...rows].join("\n");
+    navigator.clipboard.writeText(csv).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="card w-full max-w-3xl max-h-[85vh] flex flex-col shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-slate-200 font-mono">
+            {channel.name}
+          </h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleCopyCsv}
+              className="btn btn-secondary text-xs py-1 px-3"
+            >
+              {copied ? "Copied!" : "Copy CSV"}
+            </button>
+            <button
+              onClick={onClose}
+              className="text-slate-500 hover:text-slate-300 text-lg px-2"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Chart */}
+        <div className="h-48 mb-4">
+          <Line data={chartData} options={chartOptions} />
+        </div>
+
+        {/* Data table */}
+        <div className="flex-1 overflow-auto border border-slate-700 rounded">
+          <table className="w-full text-left text-xs">
+            <thead className="sticky top-0 bg-slate-800">
+              <tr className="border-b border-slate-700 text-slate-400">
+                <th className="px-3 py-2 font-medium">#</th>
+                <th className="px-3 py-2 font-medium">Timestamp</th>
+                <th className="px-3 py-2 font-medium text-right">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {channel.timestamps.map((ts, i) => (
+                <tr
+                  key={i}
+                  className="border-b border-slate-700/30 hover:bg-slate-700/20"
+                >
+                  <td className="px-3 py-1.5 text-slate-500">{i + 1}</td>
+                  <td className="px-3 py-1.5 font-mono text-slate-300">
+                    {new Date(ts).toLocaleTimeString(undefined, {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    } as Intl.DateTimeFormatOptions)}
+                  </td>
+                  <td className="px-3 py-1.5 font-mono text-sky-300 text-right">
+                    {channel.sparkline[i]?.toFixed(4)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer */}
+        <div className="mt-3 flex justify-between text-xs text-slate-500">
+          <span>{channel.sparkline.length} data points</span>
+          <span>
+            Min: {Math.min(...channel.sparkline).toFixed(3)} | Max:{" "}
+            {Math.max(...channel.sparkline).toFixed(3)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const PAGE_SIZE = 20;
+
 export default function TelemetryDashboard({ packageId }: Props) {
   const [lookback, setLookback] = useState(5);
+  const [selectedChannel, setSelectedChannel] = useState<TelemetryChannel | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [page, setPage] = useState(0);
+
+  useEffect(() => setPage(0), [searchTerm, lookback]);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["telemetry", packageId, lookback],
@@ -78,6 +239,12 @@ export default function TelemetryDashboard({ packageId }: Props) {
 
   const channels: TelemetryChannel[] = data?.channels ?? [];
   const lastUpdated = data?.lastUpdated;
+
+  const filtered = channels.filter((ch) =>
+    ch.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paginated = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   return (
     <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
@@ -89,7 +256,10 @@ export default function TelemetryDashboard({ packageId }: Props) {
           </h3>
           {channels.length > 0 && (
             <span className="rounded bg-sky-900/50 px-2 py-0.5 text-xs text-sky-300">
-              {channels.length} channel{channels.length !== 1 ? "s" : ""}
+              {searchTerm
+                ? `${filtered.length} of ${channels.length}`
+                : channels.length}{" "}
+              channel{(searchTerm ? filtered.length : channels.length) !== 1 ? "s" : ""}
             </span>
           )}
         </div>
@@ -137,43 +307,88 @@ export default function TelemetryDashboard({ packageId }: Props) {
       )}
 
       {!isLoading && !isError && channels.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
-            <thead>
-              <tr className="border-b border-slate-700 text-xs text-slate-400">
-                <th className="pb-2 pr-4 font-medium">Channel</th>
-                <th className="pb-2 pr-4 font-medium text-right">Value</th>
-                <th className="pb-2 pr-4 font-medium">Trend</th>
-              </tr>
-            </thead>
-            <tbody>
-              {channels.map((ch) => (
-                <tr
-                  key={ch.name}
-                  className="border-b border-slate-700/50 last:border-0"
-                >
-                  <td className="py-2 pr-4 font-mono text-xs text-slate-300">
-                    {ch.name}
-                  </td>
-                  <td className="py-2 pr-4 text-right font-mono text-xs text-sky-300">
-                    {ch.currentValue !== null
-                      ? typeof ch.currentValue === "number"
-                        ? ch.currentValue.toFixed(3)
-                        : ch.currentValue
-                      : "—"}
-                  </td>
-                  <td className="py-2 pr-4">
-                    {ch.sparkline.length > 1 ? (
-                      <Sparkline data={ch.sparkline} />
-                    ) : (
-                      <span className="text-xs text-slate-600">—</span>
-                    )}
-                  </td>
+        <div className="space-y-2">
+          {/* Search — shown when > 10 channels */}
+          {channels.length > 10 && (
+            <input
+              type="text"
+              placeholder="Search channels..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full bg-[#0f1117] border border-[#2a3044] rounded px-3 py-1.5 text-sm text-slate-300 placeholder-slate-600 focus:outline-none focus:border-sky-600"
+            />
+          )}
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-700 text-xs text-slate-400">
+                  <th className="pb-2 pr-4 font-medium">Channel</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Value</th>
+                  <th className="pb-2 pr-4 font-medium">Trend</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {paginated.map((ch) => (
+                  <tr
+                    key={ch.name}
+                    className="border-b border-slate-700/50 last:border-0 cursor-pointer hover:bg-slate-700/30 transition"
+                    onClick={() => setSelectedChannel(ch)}
+                  >
+                    <td className="py-2 pr-4 font-mono text-xs text-slate-300">
+                      {ch.name}
+                    </td>
+                    <td className="py-2 pr-4 text-right font-mono text-xs text-sky-300">
+                      {ch.currentValue !== null
+                        ? typeof ch.currentValue === "number"
+                          ? ch.currentValue.toFixed(3)
+                          : ch.currentValue
+                        : "—"}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {ch.sparkline.length > 1 ? (
+                        <Sparkline data={ch.sparkline} />
+                      ) : (
+                        <span className="text-xs text-slate-600">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination — shown when filtered results exceed PAGE_SIZE */}
+          {filtered.length > PAGE_SIZE && (
+            <div className="flex items-center justify-between pt-1">
+              <button
+                className="btn btn-secondary text-xs py-1 px-2"
+                disabled={page === 0}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Prev
+              </button>
+              <span className="text-xs text-slate-500">
+                Page {page + 1} of {totalPages}
+              </span>
+              <button
+                className="btn btn-secondary text-xs py-1 px-2"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
         </div>
+      )}
+
+      {/* Channel detail modal */}
+      {selectedChannel && (
+        <ChannelDetailModal
+          channel={selectedChannel}
+          onClose={() => setSelectedChannel(null)}
+        />
       )}
     </div>
   );

--- a/src/ui/src/components/TelemetryDashboard.tsx
+++ b/src/ui/src/components/TelemetryDashboard.tsx
@@ -1,0 +1,180 @@
+/**
+ * TelemetryDashboard — Live channel values table with Chart.js sparklines.
+ *
+ * Fetches channel telemetry every 10 seconds and renders a table with:
+ *   Channel Name | Current Value | Sparkline (mini Chart.js line) | Last Updated
+ */
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  getChannelTelemetry,
+  type TelemetryChannel,
+} from "../api/client";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler);
+
+const LOOKBACK_OPTIONS = [
+  { label: "1 min", value: 1 },
+  { label: "5 min", value: 5 },
+  { label: "15 min", value: 15 },
+  { label: "30 min", value: 30 },
+];
+
+interface Props {
+  packageId: string;
+}
+
+function Sparkline({ data }: { data: number[] }) {
+  const chartData = {
+    labels: data.map((_, i) => i),
+    datasets: [
+      {
+        data,
+        borderColor: "#38bdf8",
+        backgroundColor: "rgba(56,189,248,0.1)",
+        borderWidth: 1.5,
+        tension: 0.3,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+    scales: {
+      x: { display: false },
+      y: { display: false },
+    },
+    animation: false as const,
+  };
+
+  return (
+    <div className="h-8 w-32">
+      <Line data={chartData} options={options} />
+    </div>
+  );
+}
+
+export default function TelemetryDashboard({ packageId }: Props) {
+  const [lookback, setLookback] = useState(5);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["telemetry", packageId, lookback],
+    queryFn: () => getChannelTelemetry(packageId, lookback),
+    refetchInterval: 10_000,
+  });
+
+  const channels: TelemetryChannel[] = data?.channels ?? [];
+  const lastUpdated = data?.lastUpdated;
+
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h3 className="text-sm font-semibold text-slate-200">
+            Channel Values
+          </h3>
+          {channels.length > 0 && (
+            <span className="rounded bg-sky-900/50 px-2 py-0.5 text-xs text-sky-300">
+              {channels.length} channel{channels.length !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {lastUpdated && (
+            <span className="text-xs text-slate-500">
+              {new Date(lastUpdated).toLocaleTimeString()}
+            </span>
+          )}
+          <div className="flex gap-1">
+            {LOOKBACK_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setLookback(opt.value)}
+                className={`rounded px-2 py-0.5 text-xs transition ${
+                  lookback === opt.value
+                    ? "bg-sky-600 text-white"
+                    : "bg-slate-700 text-slate-400 hover:bg-slate-600"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      {isLoading && (
+        <p className="py-8 text-center text-sm text-slate-500">
+          Loading telemetry...
+        </p>
+      )}
+
+      {isError && (
+        <p className="py-8 text-center text-sm text-red-400">
+          Failed to load telemetry data.
+        </p>
+      )}
+
+      {!isLoading && !isError && channels.length === 0 && (
+        <p className="py-8 text-center text-sm text-slate-500">
+          Waiting for channel data...
+        </p>
+      )}
+
+      {!isLoading && !isError && channels.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-700 text-xs text-slate-400">
+                <th className="pb-2 pr-4 font-medium">Channel</th>
+                <th className="pb-2 pr-4 font-medium text-right">Value</th>
+                <th className="pb-2 pr-4 font-medium">Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              {channels.map((ch) => (
+                <tr
+                  key={ch.name}
+                  className="border-b border-slate-700/50 last:border-0"
+                >
+                  <td className="py-2 pr-4 font-mono text-xs text-slate-300">
+                    {ch.name}
+                  </td>
+                  <td className="py-2 pr-4 text-right font-mono text-xs text-sky-300">
+                    {ch.currentValue !== null
+                      ? typeof ch.currentValue === "number"
+                        ? ch.currentValue.toFixed(3)
+                        : ch.currentValue
+                      : "—"}
+                  </td>
+                  <td className="py-2 pr-4">
+                    {ch.sparkline.length > 1 ? (
+                      <Sparkline data={ch.sparkline} />
+                    ) : (
+                      <span className="text-xs text-slate-600">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/pages/PackageDetail.tsx
+++ b/src/ui/src/pages/PackageDetail.tsx
@@ -14,6 +14,7 @@ import ConfirmDialog from "../components/ConfirmDialog";
 import GgDeployDialog from "../components/GgDeployDialog";
 import TagEditor from "../components/TagEditor";
 import MetricsDashboard from "../components/MetricsDashboard";
+import TelemetryDashboard from "../components/TelemetryDashboard";
 import { useState, useEffect, useRef } from "react";
 import { getUser } from "../auth";
 
@@ -173,6 +174,11 @@ export default function PackageDetail() {
                 </div>
                 <DownloadButton packageId={pkg.packageId} />
               </div>
+            )}
+
+            {/* Live Channel Telemetry */}
+            {pkg.status === "READY" && (
+              <TelemetryDashboard packageId={pkg.packageId} />
             )}
 
             {/* CloudWatch Metrics Dashboard */}


### PR DESCRIPTION
## feat: Live SFC Channel Value Telemetry in Control Plane UI

### Summary

- Auto-injects an SFC File Target (`_SfcTelemetryBuffer`) into every new Launch Package to buffer all collected channel data locally as JSON
- Edge runner reads buffered files every 10s, downsamples to max 50 points per channel, and publishes batched telemetry to `sfc/{packageId}/telemetry` via MQTT
- New IoT Topic Rule + ingestion Lambda persists telemetry to a dedicated DynamoDB table (24h TTL)
- New `POST /packages/{packageId}/telemetry` API endpoint returns per-channel sparkline data (max 1000 pts/channel, 10000 total)
- New TelemetryDashboard UI component with live table, Chart.js sparklines, channel search (>10 channels), pagination (20/page), and click-to-detail modal with full chart + CSV export
- Channel Telemetry toggle in Runtime Controls (ON by default, purges buffer when OFF)

### What's new

| Layer | Change |
|-------|--------|
| **CDK** | `TelemetryTable` (DDB, TTL), `SfcTelemetryRule` (IoT Rule → Lambda), `fn-telemetry` Lambda wiring |
| **IoT Policy** | Edge devices can publish on `sfc/{id}/telemetry` |
| **LP Assembly** | Injects `FILE-TARGET` TargetType + `_SfcTelemetryBuffer` target + wires into all Schedules |
| **Edge Runner** | Telemetry publish thread (10s), downsampling (>50 pts → averaged buckets), buffer purge when disabled |
| **API** | `POST /packages/{id}/telemetry` (lookbackSeconds, max 300s), `PUT /packages/{id}/control/channel-telemetry` |
| **UI** | `TelemetryDashboard` with search, pagination, detail modal + CSV copy; toggle in `PackageControlPanel` |
